### PR TITLE
add WNS program id

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensor-hq/tensor-common",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "Common utility methods used by Tensor.",
   "sideEffects": false,
   "module": "./dist/esm/index.js",

--- a/src/tensor/constants.ts
+++ b/src/tensor/constants.ts
@@ -120,3 +120,9 @@ export const TLOCK_PDA_ADDR = PublicKey.findProgramAddressSync(
   [],
   TLOCK_PROGRAM_ID,
 )[0];
+
+// --------------------------------------- transfer hooks
+
+export const WNS_PROGRAM_ID = new PublicKey(
+  'wns1gDLt8fgLcGhWi5MqAqgXpwEP1JftKE9eZnXS1HM',
+);


### PR DESCRIPTION
So we can reference transfer hook program ids in a shared place.