### PR TITLE
Fuzzy match domain traits

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensor-hq/tensor-common",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "Common utility methods used by Tensor.",
   "sideEffects": false,
   "module": "./dist/esm/index.js",

--- a/src/tensor/traits.ts
+++ b/src/tensor/traits.ts
@@ -118,6 +118,9 @@ const isPalindrome = (str: string) =>
     .reverse()
     .join('');
 
+const serializeTraitType = (traitType: string) =>
+  traitType.toLowerCase().replace(/[_\s]/g, '');
+
 const determineNumberClub = (name: string) => {
   const number = parseInt(name);
   if (number <= 1000) {
@@ -137,7 +140,7 @@ const syntheticTraits = [
         args.name &&
         args.currentTraits &&
         isNumeric(args.name) &&
-        !args.currentTraits.has(SynthTrait.DIGITS_ONLY)
+        !args.currentTraits.has(serializeTraitType(SynthTrait.DIGITS_ONLY))
       ) {
         return { trait_type: SynthTrait.DIGITS_ONLY, value: 'true' };
       }
@@ -150,7 +153,7 @@ const syntheticTraits = [
         args.name &&
         args.currentTraits &&
         isAlpha(args.name) &&
-        !args.currentTraits.has(SynthTrait.LETTERS_ONLY)
+        !args.currentTraits.has(serializeTraitType(SynthTrait.LETTERS_ONLY))
       ) {
         return { trait_type: SynthTrait.LETTERS_ONLY, value: 'true' };
       }
@@ -163,7 +166,7 @@ const syntheticTraits = [
         args.name &&
         args.currentTraits &&
         emojiLength(args.name) > 0 &&
-        !args.currentTraits.has(SynthTrait.LANGUAGE)
+        !args.currentTraits.has(serializeTraitType(SynthTrait.LANGUAGE))
       ) {
         if (emojiLength(args.name) === visibleLength(args.name)) {
           return { trait_type: SynthTrait.LANGUAGE, value: SynthTrait.EMOJI };
@@ -180,7 +183,7 @@ const syntheticTraits = [
         args.name &&
         args.currentTraits &&
         isPalindrome(args.name) &&
-        !args.currentTraits.has(SynthTrait.PALINDROME)
+        !args.currentTraits.has(serializeTraitType(SynthTrait.PALINDROME))
       ) {
         return { trait_type: SynthTrait.PALINDROME, value: 'true' };
       }
@@ -194,7 +197,9 @@ const syntheticTraits = [
         args.currentTraits &&
         visibleLength(args.name) >= 3 &&
         visibleLength(args.name) <= 5 &&
-        !args.currentTraits.has(`${visibleLength(args.name)} Letters}`)
+        !args.currentTraits.has(
+          serializeTraitType(`${visibleLength(args.name)} Letters}`),
+        )
       ) {
         return {
           trait_type: `${visibleLength(args.name)} Letters`,
@@ -208,7 +213,10 @@ const syntheticTraits = [
     generate: (args: SynthTraitArg) => {
       if (args.name && args.currentTraits && isNumeric(args.name)) {
         const numberClub = determineNumberClub(args.name);
-        if (numberClub && !args.currentTraits.has(SynthTrait.CATEGORY)) {
+        if (
+          numberClub &&
+          !args.currentTraits.has(serializeTraitType(SynthTrait.CATEGORY))
+        ) {
           return {
             trait_type: SynthTrait.CATEGORY,
             value: numberClub,
@@ -223,7 +231,7 @@ const syntheticTraits = [
       if (
         args.name &&
         args.currentTraits &&
-        !args.currentTraits.has(SynthTrait.LANGUAGE)
+        !args.currentTraits.has(serializeTraitType(SynthTrait.LANGUAGE))
       ) {
         let matchingLanguages: Attribute[] = [];
         for (const [language, expression] of Object.entries(languageRegex)) {
@@ -251,7 +259,7 @@ const createSyntheticTraits = (
 
   // Knowing there's no standard, formatting like this reduces chance of duplicates in the future
   const currentTraits = new Set(
-    currentAttributes.map((trait) => trait.trait_type),
+    currentAttributes.map((trait) => serializeTraitType(trait.trait_type)),
   );
 
   for (const synthTrait of syntheticTraits) {

--- a/src/tensor/traits.ts
+++ b/src/tensor/traits.ts
@@ -118,6 +118,7 @@ const isPalindrome = (str: string) =>
     .reverse()
     .join('');
 
+// Remove underscores and spaces, and make it lowercase
 const serializeTraitType = (traitType: string) =>
   traitType.toLowerCase().replace(/[_\s]/g, '');
 

--- a/tests/traits.test.ts
+++ b/tests/traits.test.ts
@@ -178,7 +178,7 @@ describe('traits tests', () => {
       },
       {
         name: 'bob',
-        original: [{ trait_type: 'palindrome', value: 'true' }],
+        original: [{ trait_type: 'palindrome', value: 'true' }], // Most collections use lowercase palindrome
         expected: [
           { trait_type: 'Language', value: 'English' },
           { trait_type: '3 Letters', value: 'true' },
@@ -186,8 +186,16 @@ describe('traits tests', () => {
         ],
       },
       {
+        name: 'test',
+        original: [{ trait_type: 'language', value: 'English' }], // Most collections use lowercase language
+        expected: [
+          { trait_type: '4 Letters', value: 'true' },
+          { trait_type: 'Letters Only', value: 'true' },
+        ],
+      },
+      {
         name: 'foo',
-        original: [{ trait_type: 'LettersOnly', value: 'true' }],
+        original: [{ trait_type: 'LettersOnly', value: 'true' }],  // Some collections use this casing
         expected: [
           { trait_type: 'Language', value: 'English' },
           { trait_type: '3 Letters', value: 'true' },

--- a/tests/traits.test.ts
+++ b/tests/traits.test.ts
@@ -177,6 +177,23 @@ describe('traits tests', () => {
         ],
       },
       {
+        name: 'bob',
+        original: [{ trait_type: 'palindrome', value: 'true' }],
+        expected: [
+          { trait_type: 'Language', value: 'English' },
+          { trait_type: '3 Letters', value: 'true' },
+          { trait_type: 'Letters Only', value: 'true' },
+        ],
+      },
+      {
+        name: 'foo',
+        original: [{ trait_type: 'LettersOnly', value: 'true' }],
+        expected: [
+          { trait_type: 'Language', value: 'English' },
+          { trait_type: '3 Letters', value: 'true' },
+        ],
+      },
+      {
         name: 'abc123你好',
         original: [],
         expected: [],


### PR DESCRIPTION
Context:

There's no standard for domain trait names. As a result, we often get collections that format names incorrectly, making us include duplicate traits. Fuzzy matching prevents us from creating an additional synthetic trait.

Some examples:
<img width="351" alt="Screenshot 2024-03-03 at 12 32 04 PM" src="https://github.com/tensor-hq/tensor-common/assets/54694188/b52f630a-d34e-473a-8f49-a2ca9e11cda1">
<img width="343" alt="Screenshot 2024-03-03 at 12 32 11 PM" src="https://github.com/tensor-hq/tensor-common/assets/54694188/2ec92751-0053-46f9-aa94-c57b2804b50c">
