### PR TITLE
Confirm signature without sending tx

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensor-hq/tensor-common",
-  "version": "8.0.5",
+  "version": "8.0.6",
   "description": "Common utility methods used by Tensor.",
   "sideEffects": false,
   "module": "./dist/esm/index.js",

--- a/src/solana_contrib/transaction.ts
+++ b/src/solana_contrib/transaction.ts
@@ -165,15 +165,18 @@ export class RetryTxSender {
   constructor({
     connection,
     additionalConnections = new Array<Connection>(),
-    //pass an optional logger object (can be console, can be winston) if you want verbose logs
     logger,
+    txSig,
     opts = DEFAULT_CONFIRM_OPTS,
     timeout = DEFAULT_TIMEOUT_MS,
     retrySleep = DEFAULT_RETRY_MS,
   }: {
     connection: Connection;
     additionalConnections?: Connection[];
+    /** pass an optional logger object (can be console, can be winston) if you want verbose logs */
     logger?: Logger;
+    /** pass an optional txSig if you want to confirm at signature without resending it. */
+    txSig?: string;
     opts?: typeof DEFAULT_CONFIRM_OPTS;
     timeout?: number;
     retrySleep?: number;
@@ -181,6 +184,7 @@ export class RetryTxSender {
     this.connection = connection;
     this.additionalConnections = additionalConnections;
     this.logger = logger;
+    this.txSig = txSig;
     this.opts = opts;
     this.timeout = timeout;
     this.retrySleep = retrySleep;


### PR DESCRIPTION
Needed when we wish to send a transaction exclusively through jito bundles on the FE, while still confirming through RPC

this happens when in the Confirm Modal, the steps txs.length > 1