### PR TITLE
v0.1.3 add RetryTxSender.sendBundle

### DIFF
--- a/packages/solana-v1-contrib/package.json
+++ b/packages/solana-v1-contrib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensor-hq/solana-v1-contrib",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Utilities for Solana web3.js v1.X.",
   "sideEffects": false,
   "module": "./dist/esm/index.js",
@@ -25,7 +25,8 @@
     "bn.js": "^5.2.1",
     "bs58": "^5.0.0",
     "buffer": "^6.0.3",
-    "exponential-backoff": "^3.1.1"
+    "exponential-backoff": "^3.1.1",
+    "rate-limiter-flexible": "^4.0.0"
   },
   "devDependencies": {
     "@types/chai": "^4.3.5",

--- a/packages/solana-v1-contrib/src/index.ts
+++ b/packages/solana-v1-contrib/src/index.ts
@@ -1,3 +1,4 @@
+export * from './jito';
 export * from './lut';
 export * from './retry_tx_sender';
 export * from './rpc';

--- a/packages/solana-v1-contrib/src/jito.ts
+++ b/packages/solana-v1-contrib/src/jito.ts
@@ -15,32 +15,15 @@ const JITO_TIP_ACCOUNTS = [
 const sampleJitoTipAccount = (): PublicKey =>
   JITO_TIP_ACCOUNTS[Math.floor(Math.random() * JITO_TIP_ACCOUNTS.length)];
 
-export const makeJitoTipTx = ({
-  blockhash,
-  lastValidBlockHeight,
+export const makeJitoTipIx = ({
   payer,
   jitoTip,
 }: {
-  blockhash: string;
-  lastValidBlockHeight: number;
   payer: PublicKey;
   jitoTip: number;
 }) =>
-  new Transaction({
-    blockhash,
-    lastValidBlockHeight,
-    feePayer: payer,
-  }).add(
-    // Add compute units to prevent wallets from overriding.
-    ...prependComputeIxs(
-      [
-        SystemProgram.transfer({
-          fromPubkey: payer,
-          toPubkey: sampleJitoTipAccount(),
-          lamports: jitoTip,
-        }),
-      ],
-      1000,
-      1,
-    ),
-  );
+  SystemProgram.transfer({
+    fromPubkey: payer,
+    toPubkey: sampleJitoTipAccount(),
+    lamports: jitoTip,
+  });

--- a/packages/solana-v1-contrib/src/jito.ts
+++ b/packages/solana-v1-contrib/src/jito.ts
@@ -1,0 +1,46 @@
+import { PublicKey, SystemProgram, Transaction } from '@solana/web3.js';
+import { prependComputeIxs } from './transaction';
+
+// NB: When tipping make sure to not use Address Lookup Tables for the tip accounts.
+const JITO_TIP_ACCOUNTS = [
+  'DfXygSm4jCyNCybVYYK6DwvWqjKee8pbDmJGcLWNDXjh',
+  'HFqU5x63VTqvQss8hp11i4wVV8bD44PvwucfZ2bU7gRe',
+  'Cw8CFyM9FkoMi7K7Crf6HNQqf4uEMzpKw6QNghXLvLkY',
+  '3AVi9Tg9Uo68tJfuvoKvqKNWKkC5wPdSSdeBnizKZ6jT',
+  'ADuUkR4vqLUMWXxW9gh6D6L8pMSawimctcNZ5pGwDcEt',
+  '96gYZGLnJYVFmbjzopPSU6QiEV5fGqZNyN9nmNhvrZU5',
+  'ADaUMid9yfUytqMBgopwjb2DTLSokTSzL1zt6iGPaS49',
+  'DttWaMuVvTiduZRnguLF7jNxTgiMBZ1hyAumKUiL2KRL',
+].map((k) => new PublicKey(k));
+const sampleJitoTipAccount = (): PublicKey =>
+  JITO_TIP_ACCOUNTS[Math.floor(Math.random() * JITO_TIP_ACCOUNTS.length)];
+
+export const makeJitoTipTx = ({
+  blockhash,
+  lastValidBlockHeight,
+  payer,
+  jitoTip,
+}: {
+  blockhash: string;
+  lastValidBlockHeight: number;
+  payer: PublicKey;
+  jitoTip: number;
+}) =>
+  new Transaction({
+    blockhash,
+    lastValidBlockHeight,
+    feePayer: payer,
+  }).add(
+    // Add compute units to prevent wallets from overriding.
+    ...prependComputeIxs(
+      [
+        SystemProgram.transfer({
+          fromPubkey: payer,
+          toPubkey: sampleJitoTipAccount(),
+          lamports: jitoTip,
+        }),
+      ],
+      1000,
+      1,
+    ),
+  );

--- a/packages/solana-v1-contrib/src/jito.ts
+++ b/packages/solana-v1-contrib/src/jito.ts
@@ -1,5 +1,5 @@
-import { PublicKey, SystemProgram, Transaction } from '@solana/web3.js';
-import { prependComputeIxs } from './transaction';
+import { PublicKey, SystemProgram } from '@solana/web3.js';
+import { RateLimiterMemory, RateLimiterQueue } from 'rate-limiter-flexible';
 
 // NB: When tipping make sure to not use Address Lookup Tables for the tip accounts.
 const JITO_TIP_ACCOUNTS = [
@@ -27,3 +27,19 @@ export const makeJitoTipIx = ({
     toPubkey: sampleJitoTipAccount(),
     lamports: jitoTip,
   });
+
+/**
+ * Make a jito rate limiter with 5 RPS (per IP per region).
+ * Rate limits reference:
+ * https://jito-labs.gitbook.io/mev/searcher-resources/json-rpc-api-reference/rate-limits
+ */
+export const makeJitoRateLimiter = (maxQueueSize?: number) =>
+  new RateLimiterQueue(
+    new RateLimiterMemory({
+      points: 5, // 5 RPS per IP per region
+      duration: 1,
+    }),
+    {
+      maxQueueSize,
+    },
+  );

--- a/packages/solana-v1-contrib/src/transaction.ts
+++ b/packages/solana-v1-contrib/src/transaction.ts
@@ -14,7 +14,7 @@ import {
   VersionedTransaction,
   VersionedTransactionResponse,
 } from '@solana/web3.js';
-import { Maybe, Overwrite } from '@tensor-hq/ts-utils';
+import { Maybe, Overwrite, isNullLike } from '@tensor-hq/ts-utils';
 import bs58 from 'bs58';
 import { Buffer } from 'buffer';
 
@@ -245,4 +245,17 @@ export const legacyToV0Tx = (
   legacy: Buffer | Uint8Array | Array<number>,
 ): VersionedTransaction => {
   return new VersionedTransaction(Transaction.from(legacy).compileMessage());
+};
+
+export const txSignature = (
+  tx: VersionedTransaction | Transaction,
+): string | null => {
+  if (tx instanceof VersionedTransaction) {
+    return bs58.encode(tx.signatures[0]);
+  } else {
+    if (isNullLike(tx.signatures[0].signature)) {
+      return null;
+    }
+    return bs58.encode(tx.signatures[0].signature);
+  }
 };

--- a/packages/solana-v1-contrib/yarn.lock
+++ b/packages/solana-v1-contrib/yarn.lock
@@ -154,6 +154,7 @@ __metadata:
     exponential-backoff: ^3.1.1
     mocha: ^10.2.0
     prettier: ^2.7.1
+    rate-limiter-flexible: ^4.0.0
     ts-mocha: ^10.0.0
     ts-node: ^10.9.1
     typescript: ^4.7.4
@@ -1682,6 +1683,13 @@ __metadata:
   dependencies:
     safe-buffer: ^5.1.0
   checksum: d779499376bd4cbb435ef3ab9a957006c8682f343f14089ed5f27764e4645114196e75b7f6abf1cbd84fd247c0cb0651698444df8c9bf30e62120fbbc52269d6
+  languageName: node
+  linkType: hard
+
+"rate-limiter-flexible@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "rate-limiter-flexible@npm:4.0.1"
+  checksum: 88cb4ae4c6a94646eb4987f08ae203896fc340d84038e145958607ab711d9c703e47e55f177a4bf9bab4c637c73ee2254fffe2ec4e289d41389c8502194ca868
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adding sendBundle to the RetryTxSender, so it could be used by tlock in the backend

it looks like v0.1.2 wasn't pushed to git. this should rebase on top of that before merging/publishing