### PR TITLE
make blockTime non-optional

### DIFF
--- a/packages/solana-v1-contrib/package.json
+++ b/packages/solana-v1-contrib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensor-hq/solana-v1-contrib",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Minimal utilities built on top of the @solana/web3.js v1 API.",
   "sideEffects": false,
   "module": "./dist/esm/index.js",

--- a/packages/solana-v1-contrib/src/transaction.ts
+++ b/packages/solana-v1-contrib/src/transaction.ts
@@ -36,6 +36,7 @@ export type TransactionResponseJSON = Overwrite<
   TransactionResponse,
   {
     transaction: TransactionJSON;
+    blockTime: number;
   }
 >;
 
@@ -46,8 +47,12 @@ export type TransactionResponseLoadedAddresses = {
   };
 };
 
-export type TransactionResponseAugmented = TransactionResponse &
-  TransactionResponseLoadedAddresses;
+export type TransactionResponseAugmented = Overwrite<
+  TransactionResponse & TransactionResponseLoadedAddresses,
+  {
+    blockTime: number;
+  }
+>;
 
 export type TransactionResponseAugmentedJSON = Overwrite<
   TransactionResponseAugmented,


### PR DESCRIPTION
If we want to have the block ingestor pass txs around with valid block times, we can override the web3js field and force the blockTime to be populated.

According to Helius, the change to add blockTime was made in August 2021. So if we ever process old transactions or blockTimes aren't populated for some reason, this may cause issues.