### PR TITLE
[FEAT] Add cancelConfirm method to RetryTxSender

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensor-hq/tensor-common",
-  "version": "8.0.8",
+  "version": "8.1.8",
   "description": "Common utility methods used by Tensor.",
   "sideEffects": false,
   "module": "./dist/esm/index.js",


### PR DESCRIPTION
* Allow cancelling the tryConfirm loop. Useful in the case of a failed Jito bundle, where we know the tryConfirm loop will eventually timeout.
* Fix wsPromises + subscriptions not being cleaned up properly.
* Add basic tests for RetryTxSender tx confirming functionality.