### PR TITLE
add prepPnftRuleset

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensor-hq/tensor-common",
-  "version": "8.2.0",
+  "version": "8.2.1",
   "description": "Common utility methods used by Tensor.",
   "sideEffects": false,
   "module": "./dist/esm/index.js",

--- a/src/metaplex/token_rules.ts
+++ b/src/metaplex/token_rules.ts
@@ -17,6 +17,40 @@ import { AUTH_PROGRAM_ID, findEditionPda, findTokenRecordPda } from './pdas';
 import { fetchMetadataByMint } from './token_metadata';
 export { AuthorizationData } from '@metaplex-foundation/mpl-token-metadata';
 
+export const prepPnftRuleset = async ({
+  connection,
+  meta,
+  nftMint,
+}: {
+  connection: Connection;
+  /** If provided, skips RPC call for the the metadata account */
+  meta?: {
+    address: PublicKey;
+    metadata: Metadata;
+  };
+  nftMint: PublicKey;
+}) => {
+  if (!meta) {
+    const { address, metadata } = await fetchMetadataByMint(
+      connection,
+      nftMint,
+    );
+    if (!metadata)
+      throw new Error(`metadata account not found for mint ${nftMint}`);
+    meta = {
+      address,
+      metadata,
+    };
+  }
+
+  const ruleSet = meta.metadata.programmableConfig?.ruleSet ?? undefined;
+
+  return {
+    meta,
+    ruleSet,
+  };
+};
+
 export const prepPnftAccounts = async ({
   connection,
   meta,


### PR DESCRIPTION
New resolvers abstract away source/dest ATAs, so we all we need now is the ruleset and updated metadata.